### PR TITLE
fix: manage unix timestamp as Time

### DIFF
--- a/koios.go
+++ b/koios.go
@@ -29,6 +29,7 @@ import (
 	"net/http"
 	"net/url"
 	"runtime"
+	"strconv"
 	"time"
 
 	"github.com/shopspring/decimal"
@@ -355,6 +356,10 @@ func (v StakeAddress) String() string {
 
 func (t *Time) UnmarshalJSON(b []byte) error {
 	str := string(b)
+	if ts, err := strconv.Atoi(str); err == nil {
+		t.Time = time.Unix(int64(ts), 0)
+		return nil
+	}
 	p, err := time.Parse("\""+time.RFC3339+"\"", str)
 	if err != nil {
 		p, err = time.Parse("\"2006-01-02T15:04:05\"", str)

--- a/transaction.go
+++ b/transaction.go
@@ -32,7 +32,7 @@ type (
 		// BlockHeight is block number on chain where transaction was included.
 		BlockHeight int `json:"block_height"`
 		// BlockTime is time of the block.
-		BlockTime string `json:"block_time"`
+		BlockTime Time `json:"block_time"`
 	}
 
 	// UTxO model holds inputs and outputs for given UTxO.
@@ -132,7 +132,7 @@ type (
 		AbsoluteSlot int `json:"absolute_slot"`
 
 		// TxTimestamp is timestamp when block containing transaction was created.
-		TxTimestamp string `json:"tx_timestamp"`
+		TxTimestamp Time `json:"tx_timestamp"`
 
 		// TxBlockIndex is index of transaction within block.
 		TxBlockIndex int `json:"tx_block_index"`


### PR DESCRIPTION
## Description
Recently the koios.rest API changed transaction bock_time and tx_timestamp from string to unix timestamp as integer.
This PR just adapt the wrapped time.Time to be able to unmarshal also unix timestamp.

## Where should the reviewer start?
koios.Time UnmashalJSON was changed to attempt to parse integer as unix timestamp. 

## Motivation and context
Recently parsing response from /tx_info started to fail.

## Which issue it fixes?
Closes #32 
